### PR TITLE
Fix an issue where multiple handlers weren't registering correctly

### DIFF
--- a/mattermost_bot/bot.py
+++ b/mattermost_bot/bot.py
@@ -80,8 +80,8 @@ class PluginsManager(object):
 
     def get_plugins(self, category, text):
         has_matching_plugin = False
-        for matcher in self.commands[category]:
-            m = matcher.search(text)
+        for matcher in self.commands[category]
+            m = matcher.r.search(text)
             if m:
                 has_matching_plugin = True
                 yield self.commands[category][matcher], m.groups()
@@ -90,9 +90,14 @@ class PluginsManager(object):
             yield None, None
 
 
+class Matcher(object):
+    """This allows us to map the same regex to multiple handlers."""
+    def __init__(self, regex):
+        self.r = regex
+
 def respond_to(regexp, flags=0):
     def wrapper(func):
-        PluginsManager.commands['respond_to'][re.compile(regexp, flags)] = func
+        PluginsManager.commands['respond_to'][Matcher(re.compile(regexp, flags))] = func
         logger.info(
             'registered respond_to plugin "%s" to "%s"', func.__name__, regexp)
         return func
@@ -102,7 +107,7 @@ def respond_to(regexp, flags=0):
 
 def listen_to(regexp, flags=0):
     def wrapper(func):
-        PluginsManager.commands['listen_to'][re.compile(regexp, flags)] = func
+        PluginsManager.commands['listen_to'][Matcher(re.compile(regexp, flags))] = func
         logger.info(
             'registered listen_to plugin "%s" to "%s"', func.__name__, regexp)
         return func


### PR DESCRIPTION
The use case here is this:

```
@listen_to("(.*)")
def do_some_fallback(msg):
    ...

@listen_to("(.*)")
def do_some_other_fallback(msg):
    ...
```

We want >1 function attached to one regex "(.*)". However due to the way Python compiles regexs, these handlers were overwriting themselves here:

```
PluginsManager.commands['respond_to'][re.compile(regexp, flags)] = func
```

To convince yourself what's happening:
```
$ python
Python 2.7.13 (default, Dec 18 2016, 07:03:34)
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> mapping = {}
>>> mapping[re.compile('(.*)', 0)] = 1
>>> mapping[re.compile('(.*)', 0)] = 2
>>> mapping[re.compile('(.*)', 0)] = 3
>>> mapping
{<_sre.SRE_Pattern object at 0x10f418580>: 3}
```