### PR TITLE
ignore messages with ignore strings anywhere in message, not just the beginning

### DIFF
--- a/mattermost_bot/dispatcher.py
+++ b/mattermost_bot/dispatcher.py
@@ -37,9 +37,8 @@ class MessageDispatcher(object):
 
     def ignore(self, _msg):
         msg = self.get_message(_msg)
-        for prefix in settings.IGNORE_NOTIFIES:
-            if msg.startswith(prefix):
-                return True
+        if any(item in msg for item in settings.IGNORE_NOTIFIES):
+            return True
 
     def is_mentioned(self, msg):
         mentions = msg.get('data', {}).get('mentions', [])


### PR DESCRIPTION
The `ignore()` function in `dispatch.py` only checks if a message starts with any of the ignore strings. This led to the bot replying with `settings.DEFAULT_REPLY` whenever someone in a channel used `@here` anywhere except the start of their message.

This commit checks for the presence of `settings.IGNORE_NOTIFIES` strings anywhere in a message rather than just in the beginning.